### PR TITLE
feat: fallback handler

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -25,7 +25,7 @@ async fn main() {
     // Wrap it in a circuit breaker: opens if ≥50% of last 2 calls failed,
     // stays open 1s, then allows 1 trial in half-open.
     // If the trial succeeds, goes back to closed.
-    let breaker_layer = circuit_breaker_builder::<String, ()>()
+    let breaker_layer = circuit_breaker_builder::<String, (), _>()
         .failure_rate_threshold(0.5)
         .sliding_window_size(2) // of the past two calls fail
         .wait_duration_in_open(Duration::from_secs(1)) // open for 1 second

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -42,7 +42,7 @@ impl Circuit {
         self.state
     }
 
-    pub fn record_success(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    pub fn record_success(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized, impl Sized>) {
         self.success_count += 1;
         self.total_count += 1;
 
@@ -63,7 +63,7 @@ impl Circuit {
         }
     }
 
-    pub fn record_failure(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    pub fn record_failure(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized, impl Sized>) {
         self.failure_count += 1;
         self.total_count += 1;
 
@@ -82,7 +82,7 @@ impl Circuit {
         }
     }
 
-    pub fn try_acquire(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) -> bool {
+    pub fn try_acquire(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized, impl Sized>) -> bool {
         match self.state {
             CircuitState::Closed => true,
             CircuitState::Open => {
@@ -149,7 +149,7 @@ impl Circuit {
         self.total_count = 0;
     }
 
-    fn evaluate_window(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized>) {
+    fn evaluate_window(&mut self, config: &CircuitBreakerConfig<impl Sized, impl Sized, impl Sized>) {
         if self.total_count < config.minimum_number_of_calls {
             return;
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,14 @@
-use crate::SharedFailureClassifier;
+use crate::{BoxedFallback, SharedFailureClassifier};
 use std::time::Duration;
 
-pub(crate) struct CircuitBreakerConfig<Res, Err> {
+pub(crate) struct CircuitBreakerConfig<Req, Res, Err> {
     pub failure_rate_threshold: f64,
     pub sliding_window_size: usize,
     pub wait_duration_in_open: Duration,
     pub permitted_calls_in_half_open: usize,
     pub minimum_number_of_calls: usize,
     pub failure_classifier: SharedFailureClassifier<Res, Err>,
+    pub      fallback_handler: Option<BoxedFallback<Req, Res, Err>>,
     #[cfg(feature = "tracing")]
     pub name: Option<String>,
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,5 @@
 use crate::config::CircuitBreakerConfig;
-use crate::{CircuitBreaker, FallbackHandler, SharedFailureClassifier};
+use crate::{BoxedFallback, CircuitBreaker, SharedFailureClassifier};
 use std::sync::Arc;
 use std::time::Duration;
 use tower::Layer;
@@ -8,26 +8,26 @@ use tower::Layer;
 ///
 /// Wraps an inner service and manages its state according to circuit breaker logic.
 #[derive(Clone)]
-pub struct CircuitBreakerLayer<Res, Err> {
-    config: Arc<CircuitBreakerConfig<Res, Err>>,
+pub struct CircuitBreakerLayer<Req, Res, Err> {
+    config: Arc<CircuitBreakerConfig<Req, Res, Err>>,
 }
 
-impl<Res, Err> CircuitBreakerLayer<Res, Err> {
+impl<Req, Res, Err> CircuitBreakerLayer<Req, Res, Err> {
     /// Creates a new `CircuitBreakerLayer` from the given configuration.
-    pub(crate) fn new(config: impl Into<Arc<CircuitBreakerConfig<Res, Err>>>) -> Self {
+    pub(crate) fn new(config: impl Into<Arc<CircuitBreakerConfig<Req, Res, Err>>>) -> Self {
         Self {
             config: config.into(),
         }
     }
 
     /// Wraps the given service with the circuit breaker middleware.
-    pub fn layer<S>(&self, service: S) -> CircuitBreaker<S, Res, Err> {
+    pub fn layer<S>(&self, service: S) -> CircuitBreaker<S, Req,Res, Err> {
         CircuitBreaker::new(service, self.config.clone())
     }
 }
 
-impl<S, Res, Err> Layer<S> for CircuitBreakerLayer<Res, Err> {
-    type Service = CircuitBreaker<S, Res, Err>;
+impl<S, Req, Res, Err> Layer<S> for CircuitBreakerLayer<Req, Res, Err> {
+    type Service = CircuitBreaker<S, Req, Res, Err>;
 
     fn layer(&self, inner: S) -> Self::Service {
         self.layer(inner)
@@ -41,7 +41,7 @@ pub struct CircuitBreakerLayerBuilder<Req, Res, Err> {
     wait_duration_in_open: Duration,
     permitted_calls_in_half_open: usize,
     failure_classifier: SharedFailureClassifier<Res, Err>,
-    fallback_handler: FallbackHandler<Req, Err>,
+    fallback_handler: Option<BoxedFallback<Req, Res, Err>>,
     minimum_number_of_calls: Option<usize>,
     name: Option<String>,
 }
@@ -54,14 +54,14 @@ impl<Req, Res, Err> Default for CircuitBreakerLayerBuilder<Req, Res, Err> {
             wait_duration_in_open: Duration::from_secs(30),
             permitted_calls_in_half_open: 1,
             failure_classifier: Arc::new(|res| res.is_err()),
-            fallback_handler: Arc::new(|_| Ok(())),
+            fallback_handler: None,
             minimum_number_of_calls: None,
             name: None,
         }
     }
 }
 
-impl<Res, Err> CircuitBreakerLayerBuilder<Res, Err> {
+impl<Req, Res, Err> CircuitBreakerLayerBuilder<Req, Res, Err> {
     /// Sets the failure rate threshold at which the circuit will open.
     pub fn failure_rate_threshold(mut self, rate: f64) -> Self {
         self.failure_rate_threshold = rate;
@@ -108,13 +108,14 @@ impl<Res, Err> CircuitBreakerLayerBuilder<Res, Err> {
     }
 
     /// Builds the `CircuitBreakerLayer` with the configured parameters.
-    pub fn build(self) -> CircuitBreakerLayer<Res, Err> {
+    pub fn build(self) -> CircuitBreakerLayer<Req, Res, Err> {
         let config = CircuitBreakerConfig {
             failure_rate_threshold: self.failure_rate_threshold,
             sliding_window_size: self.sliding_window_size,
             wait_duration_in_open: self.wait_duration_in_open,
             permitted_calls_in_half_open: self.permitted_calls_in_half_open,
             failure_classifier: self.failure_classifier,
+            fallback_handler: self.fallback_handler,
             minimum_number_of_calls: self
                 .minimum_number_of_calls
                 .unwrap_or(self.sliding_window_size),

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,7 @@
 use crate::config::CircuitBreakerConfig;
 use crate::{BoxedFallback, CircuitBreaker, SharedFailureClassifier};
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tower::Layer;
@@ -104,6 +106,18 @@ impl<Req, Res, Err> CircuitBreakerLayerBuilder<Req, Res, Err> {
     /// Give this breaker a human-readable name for logs/spans.
     pub fn name<N: Into<String>>(mut self, n: N) -> Self {
         self.name = Some(n.into());
+        self
+    }
+
+    /// Sets a fallback handler function to be called when the circuit is open.
+    ///
+    /// The fallback handler receives the original request and should return a future
+    /// that resolves to a Result with the same types as the inner service.
+    pub fn fallback_handler<F>(mut self, handler: F) -> Self
+    where
+        F: Fn(Req) -> Pin<Box<dyn Future<Output = Result<Res, Err>> + Send>> + Send + Sync + 'static,
+    {
+        self.fallback_handler = Some(Box::new(handler));
         self
     }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,5 @@
 use crate::config::CircuitBreakerConfig;
-use crate::{CircuitBreaker, SharedFailureClassifier};
+use crate::{CircuitBreaker, FallbackHandler, SharedFailureClassifier};
 use std::sync::Arc;
 use std::time::Duration;
 use tower::Layer;
@@ -35,17 +35,18 @@ impl<S, Res, Err> Layer<S> for CircuitBreakerLayer<Res, Err> {
 }
 
 /// Builder for configuring and constructing a `CircuitBreakerLayer`.
-pub struct CircuitBreakerLayerBuilder<Res, Err> {
+pub struct CircuitBreakerLayerBuilder<Req, Res, Err> {
     failure_rate_threshold: f64,
     sliding_window_size: usize,
     wait_duration_in_open: Duration,
     permitted_calls_in_half_open: usize,
     failure_classifier: SharedFailureClassifier<Res, Err>,
+    fallback_handler: FallbackHandler<Req, Err>,
     minimum_number_of_calls: Option<usize>,
     name: Option<String>,
 }
 
-impl<Res, Err> Default for CircuitBreakerLayerBuilder<Res, Err> {
+impl<Req, Res, Err> Default for CircuitBreakerLayerBuilder<Req, Res, Err> {
     fn default() -> Self {
         Self {
             failure_rate_threshold: 0.5,
@@ -53,6 +54,7 @@ impl<Res, Err> Default for CircuitBreakerLayerBuilder<Res, Err> {
             wait_duration_in_open: Duration::from_secs(30),
             permitted_calls_in_half_open: 1,
             failure_classifier: Arc::new(|res| res.is_err()),
+            fallback_handler: Arc::new(|_| Ok(())),
             minimum_number_of_calls: None,
             name: None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 //! - `metrics`: enables metrics collection using the `metrics` crate.
 //! - `tracing`: enables logging and tracing using the `tracing` crate.
 
+use std::pin::Pin;
 use crate::circuit::Circuit;
 use crate::config::CircuitBreakerConfig;
 use crate::layer::CircuitBreakerLayerBuilder;
@@ -76,8 +77,7 @@ mod layer;
 pub(crate) type FailureClassifier<Res, Err> = dyn Fn(&Result<Res, Err>) -> bool + Send + Sync;
 pub(crate) type SharedFailureClassifier<Res, Err> = Arc<FailureClassifier<Res, Err>>;
 
-pub(crate) type FallbackHandler<Req, Err> = dyn Fn(Req) -> Result<(), Err> + Send;
-// pub(crate) type SharedFallbackHandler<Res> = Arc<FallbackHandler<Res>>;
+pub(crate) type BoxedFallback<Req, Res, Err> = Box<dyn Fn(Req) -> Pin<Box<dyn Future<Output = Result<Res, Err>> + Send>> + Send + Sync>;
 
 #[cfg(feature = "tracing")]
 pub(crate) static DEFAULT_CIRCUIT_BREAKER_NAME: &str = "<unnamed>";
@@ -110,15 +110,15 @@ pub fn circuit_breaker_builder<Req, Res, Err>() -> CircuitBreakerLayerBuilder<Re
 /// A Tower Service that applies circuit breaker logic to an inner service.
 ///
 /// Manages the circuit state and controls calls to the inner service accordingly.
-pub struct CircuitBreaker<S, Res, Err> {
+pub struct CircuitBreaker<S, Req, Res, Err> {
     inner: S,
     circuit: Arc<Mutex<Circuit>>,
-    config: Arc<CircuitBreakerConfig<Res, Err>>,
+    config: Arc<CircuitBreakerConfig<Req, Res, Err>>,
 }
 
-impl<S, Res, Err> CircuitBreaker<S, Res, Err> {
+impl<S, Req, Res, Err> CircuitBreaker<S, Req, Res, Err> {
     /// Creates a new `CircuitBreaker` wrapping the given service and configuration.
-    pub(crate) fn new(inner: S, config: Arc<CircuitBreakerConfig<Res, Err>>) -> Self {
+    pub(crate) fn new(inner: S, config: Arc<CircuitBreakerConfig<Req, Res, Err>>) -> Self {
         Self {
             inner,
             circuit: Arc::new(Mutex::new(Circuit::new())),
@@ -151,7 +151,7 @@ impl<S, Res, Err> CircuitBreaker<S, Res, Err> {
     }
 }
 
-impl<S, Req, Res, Err> Service<Req> for CircuitBreaker<S, Res, Err>
+impl<S, Req, Res, Err> Service<Req> for CircuitBreaker<S, Req, Res, Err>
 where
     S: Service<Req, Response = Res, Error = Err> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -172,6 +172,9 @@ where
     fn call(&mut self, req: Req) -> Self::Future {
         let config = Arc::clone(&self.config);
         let circuit = Arc::clone(&self.circuit);
+        // let fallback = self.config.fallback_handler.as_ref();
+        let fallback = Arc::clone(&self.config.fallback_handler.unwrap());
+
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
@@ -231,6 +234,10 @@ where
                     let counter = counter!("circuitbreaker_calls_total", "outcome" => "rejected");
                     counter.increment(1);
                 }
+                // Call fallback here with the request. Do we care what it returns?
+                // if let Some(fallback) = self.config.fallback_handler.as_ref() {
+                //     // return fallback(req).await;
+                // }
                 return Err(CircuitBreakerError::OpenCircuit);
             }
 
@@ -253,13 +260,14 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    fn dummy_config() -> CircuitBreakerConfig<(), ()> {
+    fn dummy_config() -> CircuitBreakerConfig<(), (), () > {
         CircuitBreakerConfig {
             failure_rate_threshold: 0.5,
             sliding_window_size: 10,
             wait_duration_in_open: Duration::from_secs(1),
             permitted_calls_in_half_open: 1,
             failure_classifier: Arc::new(|r| r.is_err()),
+            fallback_handler: None,
             minimum_number_of_calls: 10,
             #[cfg(feature = "tracing")]
             name: Some("test".into()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     // Build a circuit breaker layer with custom settings
-//!     let circuit_breaker_layer = circuit_breaker_builder::<_, ()>()
+//!     let circuit_breaker_layer = circuit_breaker_builder::<_, (), _>()
 //!         .failure_rate_threshold(0.3)
 //!         .sliding_window_size(50)
 //!         .wait_duration_in_open(Duration::from_secs(10))
@@ -76,6 +76,9 @@ mod layer;
 pub(crate) type FailureClassifier<Res, Err> = dyn Fn(&Result<Res, Err>) -> bool + Send + Sync;
 pub(crate) type SharedFailureClassifier<Res, Err> = Arc<FailureClassifier<Res, Err>>;
 
+pub(crate) type FallbackHandler<Req, Err> = dyn Fn(Req) -> Result<(), Err> + Send;
+// pub(crate) type SharedFallbackHandler<Res> = Arc<FallbackHandler<Res>>;
+
 #[cfg(feature = "tracing")]
 pub(crate) static DEFAULT_CIRCUIT_BREAKER_NAME: &str = "<unnamed>";
 
@@ -83,7 +86,7 @@ pub(crate) static DEFAULT_CIRCUIT_BREAKER_NAME: &str = "<unnamed>";
 static METRICS_INIT: Once = Once::new();
 
 /// Returns a new builder for a `CircuitBreakerLayer`.
-pub fn circuit_breaker_builder<Res, Err>() -> CircuitBreakerLayerBuilder<Res, Err> {
+pub fn circuit_breaker_builder<Req, Res, Err>() -> CircuitBreakerLayerBuilder<Req, Res, Err> {
     #[cfg(feature = "metrics")]
     {
         METRICS_INIT.call_once(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,7 @@ where
     fn call(&mut self, req: Req) -> Self::Future {
         let config = Arc::clone(&self.config);
         let circuit = Arc::clone(&self.circuit);
-        // let fallback = self.config.fallback_handler.as_ref();
-        let fallback = Arc::clone(&self.config.fallback_handler.unwrap());
+        let fallback = config.fallback_handler.clone();
 
         let mut inner = self.inner.clone();
 
@@ -234,11 +233,13 @@ where
                     let counter = counter!("circuitbreaker_calls_total", "outcome" => "rejected");
                     counter.increment(1);
                 }
-                // Call fallback here with the request. Do we care what it returns?
-                // if let Some(fallback) = self.config.fallback_handler.as_ref() {
-                //     // return fallback(req).await;
-                // }
-                return Err(CircuitBreakerError::OpenCircuit);
+
+                // Use fallback if available, otherwise return circuit open error
+                if let Some(fallback_fn) = fallback {
+                    return fallback_fn(req).await.map_err(CircuitBreakerError::Inner);
+                } else {
+                    return Err(CircuitBreakerError::OpenCircuit);
+                }
             }
 
             let result = inner.call(req).await;


### PR DESCRIPTION
Super basic fallback implementation. A fallback is `Option`ally configured and if found, runs with the request and assumes all open circuit return values over the core circuit breaker.

```rust
// Type alias for an ergonomic fallback handler
pub(crate) type BoxedFallback<Req, Res, Err> =
    Box<dyn Fn(Req) -> Pin<Box<dyn Future<Output = Result<Res, Err>> + Send>> + Send + Sync>;

// Inside your CircuitBreaker implementation...
fn call(&mut self, req: Req) -> Self::Future {
    // Clone all necessary references to avoid lifetime issues
    let circuit = self.circuit.clone();
    let fallback = self.fallback.clone();
    let inner = self.inner.clone();

    Box::pin(async move {
        // Check circuit state
        let state = circuit.lock().await.state();
        if state == CircuitState::Open {
            // Circuit is OPEN
            if let Some(fallback_fn) = fallback {
                // Fallback is configured -> call it and return its result directly
                fallback_fn(req).await
            } else {
                // No fallback -> return circuit open error
                Err(CircuitBreakerError::Open.into())
            }
        } else {
            // Circuit is CLOSED (or HALF_OPEN if you choose to allow)
            // Proceed with normal call to the inner service
            inner.call(req).await
        }
    })
}
```